### PR TITLE
fixes #295 groupのサムネが変わったとき、indexの情報も更新するように修正

### DIFF
--- a/src/ipc/images.ts
+++ b/src/ipc/images.ts
@@ -31,6 +31,7 @@ export class IpcId extends IpcIdBase {
     static readonly IMAGE_INFO_LIST_UPDATED: string = IpcId.generateIpcId()
     static readonly IMAGE_UPLOAD_PROGRESS: string = IpcId.generateIpcId()
     static readonly RELOAD_IMAGES: string = IpcId.generateIpcId()
+    static readonly GROUP_THUMB_CHANGED: string = IpcId.generateIpcId()
   }
 
   static readonly ACTUAL_REQUEST_THUMB_IMAGE: string = IpcId.generateIpcId()
@@ -116,4 +117,12 @@ export type ImageUploadProgress = {
 export type SortGroupImages = {
   workspaceId: string
   imageIds: string[]
+  groupId: string
+  currThumbImageId: string
+}
+
+export type GroupThumbChanged = {
+  workspaceId: string
+  prevThumbImageId: string
+  image: ImageInfo
 }

--- a/src/view/contents/collectImagesHooks.ts
+++ b/src/view/contents/collectImagesHooks.ts
@@ -12,7 +12,7 @@ export const useCollectImage = (
   tagIds: string[],
   searchType: string,
   clearSelectedImage: () => void
-): [ImageList, boolean, React.RefObject<HTMLDivElement>] => {
+): [ImageList, boolean, React.RefObject<HTMLDivElement>, (targetImageId: string, imageInfo: ImageInfo) => void] => {
   const [imageList, setImageList] = useState({ page: 0, images: [] } as ImageList)
   const [nextPageRequestableState, setNextPageRequestable] = useState(false)
 
@@ -119,5 +119,23 @@ export const useCollectImage = (
     }
   })
 
-  return [imageList, nextPageRequestableState, ref]
+  const replaceImageInfo = (targetImageId: string, imageInfo: ImageInfo) => {
+    setImageList(prevState => {
+      const nextImages = [...prevState.images]
+
+      for (let i = 0; i < nextImages.length; i++) {
+        if (nextImages[i].image_id == targetImageId) {
+          // 差し替え
+          nextImages[i] = imageInfo
+        }
+      }
+
+      return {
+        images: nextImages,
+        page: prevState.page,
+      }
+    })
+  }
+
+  return [imageList, nextPageRequestableState, ref, replaceImageInfo]
 }

--- a/src/view/contents/imaveView/imageView.tsx
+++ b/src/view/contents/imaveView/imageView.tsx
@@ -118,6 +118,8 @@ export const ImageView: React.VFC<ImageViewProps> = props => {
     const sortGroupImages: SortGroupImages = {
       workspaceId: props.workspaceId,
       imageIds: imageIds,
+      groupId: imageInfoList[0].group_id,
+      currThumbImageId: props.imageId,
     }
 
     window.api.send(ImagesIpcId.ToMainProc.SORT_GROUP_IMAGES, JSON.stringify(sortGroupImages))


### PR DESCRIPTION
<!--
マージ時に削除しない場合はresolvesの代わりにissueを使う
複数のissueに紐付けたい場合はresolves #0, resolves #0のようにできる
-->
resolves #295

## チェックリスト
- [x] ライブラリを更新したとき、`npm run generate-notice`で`NOTICE`を更新する
- [x] `backend/blueprint`以下を編集したとき、`backend/blueprint/converter.sh`を実行し、生成される`docs/index.html`をコミットに含める
