### PR TITLE
fixes #302 React.VFCがdeprecatedになっているので修正する

### DIFF
--- a/src/view/backendSetup.tsx
+++ b/src/view/backendSetup.tsx
@@ -6,7 +6,7 @@ type BackendSetupProps = {
   backendState: BackendState
 }
 
-export const BackendSetup: React.VFC<BackendSetupProps> = props => {
+export const BackendSetup: React.FC<BackendSetupProps> = props => {
   const backendDownload = () => {
     window.api.send(BackendSetupIpcId.ToMainProc.BACKEND_DOWNLOAD)
   }

--- a/src/view/component/atmos/tag.tsx
+++ b/src/view/component/atmos/tag.tsx
@@ -20,7 +20,7 @@ type TagProps = {
   onDeleteClick: ((tagId: string) => void) | null
 }
 
-export const Tag: React.VFC<TagProps> = props => {
+export const Tag: React.FC<TagProps> = props => {
   const workspaceId = useRecoilValue(workspaceIdAtom)
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const [{ isDragging }, dragRef] = useDrag({

--- a/src/view/component/organisms/confirmModal.tsx
+++ b/src/view/component/organisms/confirmModal.tsx
@@ -10,7 +10,7 @@ type ConfirmModalProps = {
   onClose: () => void
 }
 
-export const ConfirmModal: React.VFC<ConfirmModalProps> = props => {
+export const ConfirmModal: React.FC<ConfirmModalProps> = props => {
   const reactModalStyle: ReactModal.Styles = {
     content: {
       top: '50%',

--- a/src/view/component/organisms/searchPanel.tsx
+++ b/src/view/component/organisms/searchPanel.tsx
@@ -16,7 +16,7 @@ type SearchPanelProps = {
   onTagDeleteClick: (tagId: string) => void
 }
 
-export const SearchPanel: React.VFC<SearchPanelProps> = props => {
+export const SearchPanel: React.FC<SearchPanelProps> = props => {
   const workspaceId = useRecoilValue(workspaceIdAtom)
   const tagGroupListState = useRecoilValue(tagGroupListAtom)
   const selectedTagIds = useRecoilValue(searchTagIdsAtom)

--- a/src/view/component/organisms/tagCtrlPanel.tsx
+++ b/src/view/component/organisms/tagCtrlPanel.tsx
@@ -27,7 +27,7 @@ type TagCtrlPanelProps = {
   onRemoveTag: ((tagId: string) => void) | null
 }
 
-export const TagCtrlPanel: React.VFC<TagCtrlPanelProps> = props => {
+export const TagCtrlPanel: React.FC<TagCtrlPanelProps> = props => {
   const workspaceId = useRecoilValue(workspaceIdAtom)
   const setTagAllList = useSetRecoilState(tagListAtom)
   const tagGroupListState = useRecoilValue(tagGroupListAtom)

--- a/src/view/contents/browseImage.tsx
+++ b/src/view/contents/browseImage.tsx
@@ -26,7 +26,7 @@ type BrowseImageProps = {
   dsb_ref: React.RefObject<HTMLDivElement>
 }
 
-export const BrowseImage: React.VFC<BrowseImageProps> = props => {
+export const BrowseImage: React.FC<BrowseImageProps> = props => {
   const workspaceId = useRecoilValue(workspaceIdAtom)
   const setTagAllList = useSetRecoilState(tagListAtom)
   const [selectedImageIds, setSelectedImageIds] = useState([] as string[])

--- a/src/view/contents/imageIndexView.tsx
+++ b/src/view/contents/imageIndexView.tsx
@@ -29,7 +29,7 @@ type SelectedSingleImageId = {
   imageId: string | null
 }
 
-export const ImageIndexView: React.VFC<ImageIndexViewProps> = props => {
+export const ImageIndexView: React.FC<ImageIndexViewProps> = props => {
   const SEND_IMAGE_COUNT_MAX = 5
   const workspaceId = useRecoilValue(workspaceIdAtom)
   const [selectedImageId, setSelectedImageId] = useState([] as string[])

--- a/src/view/contents/imageSideBar.tsx
+++ b/src/view/contents/imageSideBar.tsx
@@ -15,7 +15,7 @@ type ImageSideBarProps = {
   dsb_ref: React.RefObject<HTMLDivElement>
 }
 
-export const ImageSideBar: React.VFC<ImageSideBarProps> = props => {
+export const ImageSideBar: React.FC<ImageSideBarProps> = props => {
   const workspaceId = useRecoilValue(workspaceIdAtom)
   const setTagAllList = useSetRecoilState(tagListAtom)
   const [imageInfoList, setImageInfoList] = useRecoilState(imageInfoListAtom)

--- a/src/view/contents/imaveView/imageView.tsx
+++ b/src/view/contents/imaveView/imageView.tsx
@@ -15,7 +15,7 @@ type ImageViewProps = {
   onPrevImageEvent: Event
 }
 
-export const ImageView: React.VFC<ImageViewProps> = props => {
+export const ImageView: React.FC<ImageViewProps> = props => {
   const workspaceId = useRecoilValue(workspaceIdAtom)
   const [imageInfoList, setImageInfoList] = useState([] as ImageInfo[])
   const [imageDataList, setImageDataList] = useState([] as ImageData[])

--- a/src/view/contents/imaveView/imageViewMulti.tsx
+++ b/src/view/contents/imaveView/imageViewMulti.tsx
@@ -9,7 +9,7 @@ type ImageViewMultiProps = {
   onImageSelect: (imageId: string) => void
 }
 
-export const ImageViewMulti: React.VFC<ImageViewMultiProps> = props => {
+export const ImageViewMulti: React.FC<ImageViewMultiProps> = props => {
   return (
     <div className={`images-area images-area-multi ${props.isShowSidePanel ? 'show-side-panel' : ''}`}>
       {props.images.map(imageBulk => {

--- a/src/view/contents/imaveView/imageViewSingle.tsx
+++ b/src/view/contents/imaveView/imageViewSingle.tsx
@@ -13,7 +13,7 @@ type Point = {
   y: number
 }
 
-export const ImageViewSingle: React.VFC<ImageViewSingleProps> = props => {
+export const ImageViewSingle: React.FC<ImageViewSingleProps> = props => {
   const [isHoming, setIsHoming] = useState(false)
   const [dragStartPagePoint, setDragStartPagePoint] = useState(null as null | Point)
   const [dragStartScrollPoint, setDragStartScrollPoint] = useState(null as null | Point)

--- a/src/view/contents/tagManage.tsx
+++ b/src/view/contents/tagManage.tsx
@@ -49,7 +49,7 @@ const reactModalStyle: ReactModal.Styles = {
   },
 }
 
-const TagGroupMenu: React.VFC<TagGroupMenuProps> = props => {
+const TagGroupMenu: React.FC<TagGroupMenuProps> = props => {
   const workspaceId = useRecoilValue(workspaceIdAtom)
   const setTagAllList = useSetRecoilState(tagListAtom)
   const onDrop = (item: any) => {
@@ -99,7 +99,7 @@ const TagGroupMenu: React.VFC<TagGroupMenuProps> = props => {
   )
 }
 
-export const TagManage: React.VFC<TagManageProps> = props => {
+export const TagManage: React.FC<TagManageProps> = props => {
   const workspaceId = useRecoilValue(workspaceIdAtom)
   const setTagAllList = useSetRecoilState(tagListAtom)
   const [tagGroupListState, setTagGroupList] = useRecoilState(tagGroupListAtom)

--- a/src/view/contentsArea.tsx
+++ b/src/view/contentsArea.tsx
@@ -9,7 +9,7 @@ type contentsAreaProps = {
   dsb_ref: React.RefObject<HTMLDivElement>
 }
 
-export const ContentsArea: React.VFC<contentsAreaProps> = props => {
+export const ContentsArea: React.FC<contentsAreaProps> = props => {
   const workspaceId = useRecoilValue(workspaceIdAtom)
   const [showAImageState, setShowAImage] = useState(null as string | null)
   const [currMode, _] = useRecoilState(menuModeAtom)

--- a/src/view/mainMenu.tsx
+++ b/src/view/mainMenu.tsx
@@ -22,7 +22,7 @@ type MainMenuProps = {
   dsb_ref: React.RefObject<HTMLElement>
 }
 
-export const MainMenu: React.VFC<MainMenuProps> = props => {
+export const MainMenu: React.FC<MainMenuProps> = props => {
   const workspace = useRecoilValue(workspaceAtom)
   const tagGroupListState = useRecoilValue(tagGroupListAtom)
   const [FavoriteTagListState, setFavoriteTagList] = useState([] as TagInfo[])


### PR DESCRIPTION
<!--
マージ時に削除しない場合はresolvesの代わりにissueを使う
複数のissueに紐付けたい場合はresolves #0, resolves #0のようにできる
-->
resolves #302

## チェックリスト
- [x] ライブラリを更新したとき、`npm run generate-notice`で`NOTICE`を更新する
- [x] `backend/blueprint`以下を編集したとき、`backend/blueprint/converter.sh`を実行し、生成される`docs/index.html`をコミットに含める
